### PR TITLE
Add cleanup as web API endpoint

### DIFF
--- a/examples/test15/recorder.lua
+++ b/examples/test15/recorder.lua
@@ -117,4 +117,10 @@ web["/recorder/unpause"]=function(r,s,msg,path,query,ctx) -- luacheck: no unused
 	msg.status_code=200
 	msg.response_body:complete()
 end
+web["/recorder/cleanup"]=function(r,s,msg,path,query,ctx) -- luacheck: no unused args
+	M:cleanup()
+	log.warning("cleanup")
+	msg.status_code=200
+	msg.response_body:complete()
+end
 return M


### PR DESCRIPTION
If you pause and unpause the pipeline, the recording just gets appended. If the pipeline is cleaned and then unpaused, the old recording is erased and a new recording is started which is what I want in my case. 